### PR TITLE
Configure console logging

### DIFF
--- a/bnc_anc_pkg/__init__.py
+++ b/bnc_anc_pkg/__init__.py
@@ -1,0 +1,14 @@
+"""bnc_anc_pkg package initialization.
+
+This module configures logging to ensure that messages emitted by modules in
+the package are displayed on the console. The configuration is minimal and
+only applies if no other logging handlers have been set up.
+"""
+
+import logging
+import sys
+
+
+if not logging.getLogger().handlers:
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+


### PR DESCRIPTION
## Summary
- Configure package to initialize logging so INFO-level messages appear on the console

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895dc17f2b883239f140cc0df6e6034