### PR TITLE
feat: improve test flexibility

### DIFF
--- a/bnc_anc_pkg/telegram.py
+++ b/bnc_anc_pkg/telegram.py
@@ -1,8 +1,8 @@
 import requests
-from .config import TG_TOKEN, TG_CHAT_ID
+from .config import TG_TOKEN, TG_CHAT_ID, TEST_MODE
 
 def push_telegram(text: str) -> None:
-    if not TG_TOKEN or not TG_CHAT_ID:
+    if TEST_MODE or not TG_TOKEN or not TG_CHAT_ID:
         return
     try:
         url = f"https://api.telegram.org/bot{TG_TOKEN}/sendMessage"

--- a/tests/fake_news_ws.py
+++ b/tests/fake_news_ws.py
@@ -1,3 +1,4 @@
+import argparse
 import asyncio
 import json
 import os
@@ -26,8 +27,7 @@ async def _fake_client(uri, exchanges):
         await handle_payload(payload, exchanges)
 
 
-async def run_fake_ws():
-    exchanges = build_exchanges()
+async def run_fake_ws(exchanges):
     server = await websockets.serve(_fake_server, "127.0.0.1", 8765)
     try:
         await _fake_client("ws://127.0.0.1:8765", exchanges)
@@ -37,4 +37,14 @@ async def run_fake_ws():
 
 
 if __name__ == "__main__":
-    asyncio.run(run_fake_ws())
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--exchange",
+        dest="exchanges",
+        action="append",
+        default=[],
+        help="Exchange to enable (can be used multiple times)",
+    )
+    args = parser.parse_args()
+    exchanges = build_exchanges(args.exchanges or None)
+    asyncio.run(run_fake_ws(exchanges))


### PR DESCRIPTION
## Summary
- skip telegram notifications when running in test mode
- allow selecting exchanges for tests and add CLI flag to fake news script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895e37b631083238c6e44f19ec729a4