### PR TITLE
Make fake news websocket test fully async

### DIFF
--- a/tests/fake_news_ws.py
+++ b/tests/fake_news_ws.py
@@ -39,10 +39,10 @@ async def run_fake_ws(exchanges):
         await server.wait_closed()
 
 
-def main():
+async def main():
     exchanges = build_exchanges(EXCHANGES)
-    asyncio.run(run_fake_ws(exchanges))
+    await run_fake_ws(exchanges)
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Convert `tests/fake_news_ws.py` to use an async `main` ensuring `build_exchanges` runs within an active event loop

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895e8c610588323be8b2956aced02d3