### PR TITLE
Fix KuCoin TP/SL orders not created

### DIFF
--- a/bnc_anc_pkg/exchanges/kucoin.py
+++ b/bnc_anc_pkg/exchanges/kucoin.py
@@ -96,9 +96,15 @@ class KuCoinFuturesClient(ExchangeClient):
             if r.status < 200 or r.status >= 300:
                 raise RuntimeError(f"{r.status} {r.reason}. Body={txt}")
             try:
-                return json.loads(txt)
+                data = json.loads(txt)
             except Exception:
                 return txt
+            if isinstance(data, dict):
+                code = data.get("code")
+                if code is not None and str(code) != "200000":
+                    msg = data.get("msg") or data.get("message")
+                    raise RuntimeError(f"KuCoin API error {code}: {msg}")
+            return data
 
     async def get_contract(self, symbol: str) -> Dict[str, Any]:
         return (await self._req("GET", CONTRACT_DETAIL.replace("{symbol}", symbol)))["data"]
@@ -156,6 +162,7 @@ class KuCoinFuturesClient(ExchangeClient):
                 "stopPriceType": "MP",
                 "triggerStopUpPrice": tp_price,
                 "reduceOnly": True,
+                "closeOrder": True,
             }
             sl_req = {
                 "clientOid": str(uuid.uuid4()),
@@ -165,6 +172,7 @@ class KuCoinFuturesClient(ExchangeClient):
                 "stopPriceType": "MP",
                 "triggerStopDownPrice": sl_price,
                 "reduceOnly": True,
+                "closeOrder": True,
             }
         else:
             tp_price = _round_down_to_tick(tp_raw, tick)
@@ -177,6 +185,7 @@ class KuCoinFuturesClient(ExchangeClient):
                 "stopPriceType": "MP",
                 "triggerStopDownPrice": tp_price,
                 "reduceOnly": True,
+                "closeOrder": True,
             }
             sl_req = {
                 "clientOid": str(uuid.uuid4()),
@@ -186,6 +195,7 @@ class KuCoinFuturesClient(ExchangeClient):
                 "stopPriceType": "MP",
                 "triggerStopUpPrice": sl_price,
                 "reduceOnly": True,
+                "closeOrder": True,
             }
 
         await self._req("POST", ST_ORDERS_PATH, j=tp_req)


### PR DESCRIPTION
## Summary
- Check KuCoin API responses and raise errors on failure
- Mark KuCoin TP/SL orders as close orders to ensure they are submitted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689636e291f083238e82d3194dcb7a55